### PR TITLE
fix: bound retained draft send recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
 
 - Direct CDP submission recovery: after a nominal Send leaves the exact prompt
   staged with no new turn or streaming evidence, revalidate the original target
-  and page state atomically before issuing at most one page-side Send click.
-  Delayed first commits cancel recovery, and this path never falls back to Enter.
+  and page state atomically before issuing at most one page-side Send click. Only
+  a finite pre-dispatch turn baseline can authorize recovery, and a per-document
+  token blocks same-target reloads or replacements. Delayed first commits cancel
+  recovery, and this path never falls back to Enter.
 - Direct CDP lifecycle: separate persistent profile identity from browser
   process lifetime. Dedicated Chrome now defaults to `while-needed`, releases
   tab leases before final drain, rechecks under the profile lock, and closes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### Fixed
 
+- Direct CDP submission recovery: after a nominal Send leaves the exact prompt
+  staged with no new turn or streaming evidence, revalidate the original target
+  and page state atomically before issuing at most one page-side Send click.
+  Delayed first commits cancel recovery, and this path never falls back to Enter.
 - Direct CDP lifecycle: separate persistent profile identity from browser
   process lifetime. Dedicated Chrome now defaults to `while-needed`, releases
   tab leases before final drain, rechecks under the profile lock, and closes

--- a/docs/windows-work.md
+++ b/docs/windows-work.md
@@ -20,6 +20,9 @@ Future Windows gotchas belong here. Update this doc when you learn something new
   retry, one exact user turn, a cleared composer, and a captured Pro response;
   a first click released 1.7 seconds late was observed by the atomic retry gate,
   which cancelled the second dispatch and again produced exactly one user turn.
+  Retry authorization must capture a finite turn baseline and per-document token
+  before the nominal Send; post-dispatch fallback counts remain observation-only,
+  and a same-target reload or replacement document fails the owner gate closed.
   Windows is the reproduction environment, not a proven platform-specific root
   cause.
 - The historical `Session with given id not found.` run was emitted by

--- a/docs/windows-work.md
+++ b/docs/windows-work.md
@@ -5,10 +5,26 @@ Read this file whenever you're working from Windows and add new findings so the 
 - Browser engine now allowed on Windows; expect more flakiness. If automation fails, rerun with `--engine api --wait` or point `--remote-chrome` to a running Chrome with remote debugging.
 - Chrome DevTools via mcporter: `chrome-devtools` server needs `CHROME_DEVTOOLS_URL` from a live session; without it `mcporter call chrome-devtools.*` fails. Expect this to be unset on Windows unless you bring your own Chrome session/URL.
 - The agent-scripts `runner` helper can fail under PowerShell/CMD because of CRLF and bash expectations. If it explodes, run commands directly (`pnpm ...`, `git add/commit`) instead.
-- browser-tools binary: not built in `agent-scripts/bin` on Windows; `pnpm tsx scripts/browser-tools.ts` also fails there (no package manifest). Use a macOS-built binary or run from macOS if you need it.
+- `scripts/browser-tools.ts start` is macOS-oriented: it shells out to `killall`,
+  `mkdir -p`, and optionally `rsync`, so it is not a valid Windows launcher.
+  Run browser tools from this repository when using the other subcommands, and
+  use Oracle's dedicated-browser lifecycle for Windows Chrome startup.
 - Prefer PowerShell + pnpm directly; watch for CRLF warnings when touching tracked files.
 - WSL browser launch host detection: a systemd-resolved stub such as `nameserver 127.0.0.53` is guest loopback, not the Windows host. Keep resolver-derived non-loopback hosts for Windows Chrome compatibility, but route resolver-derived `127/8` values to the standard local Chrome launcher.
 
 Future Windows gotchas belong here. Update this doc when you learn something new.
 
 - ChatGPT sidebar/history labels can include phrases like "Login setup instruction"; login probes must match exact auth CTAs, not any visible text starting with login, or manual-login automation loops forever before typing.
+- Direct-CDP retained-draft recovery has Windows live proof on candidate
+  `7362caf`: a forced first trusted-click no-op produced one bounded page-side
+  retry, one exact user turn, a cleared composer, and a captured Pro response;
+  a first click released 1.7 seconds late was observed by the atomic retry gate,
+  which cancelled the second dispatch and again produced exactly one user turn.
+  Windows is the reproduction environment, not a proven platform-specific root
+  cause.
+- The historical `Session with given id not found.` run was emitted by
+  Chromium's DevTools dispatcher for a missing flattened child session (CDP
+  error `-32001`), not by the Oracle application-session store, an agent terminal
+  session, or MCP. Treat that page session as stale: enumerate browser-level
+  targets and attach fresh by durable target/conversation identity. Response
+  recovery must remain unavailable when `proTurnCommitted:false`.

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { ChromeClient, BrowserLogger } from "../types.js";
 import {
   INPUT_SELECTORS,
@@ -24,6 +25,7 @@ const ENTER_KEY_EVENT = {
 } as const;
 const ENTER_KEY_TEXT = "\r";
 const RETAINED_DRAFT_RETRY_DELAY_MS = 2_000;
+const SUBMISSION_DOCUMENT_TOKEN_PROPERTY = "__oracleSubmissionDocumentToken";
 
 // Input.insertText gives ProseMirror plain text, but ProseMirror renders each
 // line as a direct block. HTMLElement.innerText inserts an extra newline
@@ -204,9 +206,30 @@ export async function submitPrompt(
     });
   }
 
+  const preDispatchBaseline =
+    typeof deps.baselineTurns === "number" &&
+    Number.isFinite(deps.baselineTurns) &&
+    deps.baselineTurns >= 0
+      ? Math.floor(deps.baselineTurns)
+      : null;
+  const retainedDraftRecoveryEligible =
+    preDispatchBaseline !== null &&
+    !deps.attachmentNames?.length &&
+    typeof deps.isSubmissionOwner === "function";
+  const submissionDocumentToken = retainedDraftRecoveryEligible ? randomUUID() : null;
   const promptLength = prompt.length;
   const postVerification = await runtime.evaluate({
     expression: `(() => {
+      const submissionDocumentToken = ${JSON.stringify(submissionDocumentToken)};
+      const submissionDocumentTokenProperty = ${JSON.stringify(SUBMISSION_DOCUMENT_TOKEN_PROPERTY)};
+      if (submissionDocumentToken) {
+        Object.defineProperty(document, submissionDocumentTokenProperty, {
+          configurable: true,
+          enumerable: false,
+          value: submissionDocumentToken,
+          writable: true,
+        });
+      }
       const editor = document.querySelector(${primarySelectorLiteral});
       const fallback = document.querySelector(${fallbackSelectorLiteral});
       const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
@@ -225,6 +248,9 @@ export async function submitPrompt(
         fallbackValue: fallback?.value ?? '',
         activeValue: readComposerValue(active),
         href: typeof location === 'object' && location.href ? location.href : '',
+        documentTokenStored:
+          !submissionDocumentToken ||
+          document[submissionDocumentTokenProperty] === submissionDocumentToken,
       };
     })()`,
     returnByValue: true,
@@ -233,6 +259,8 @@ export async function submitPrompt(
   const observedFallback = postVerification.result?.value?.fallbackValue ?? "";
   const observedActive = postVerification.result?.value?.activeValue ?? "";
   const submissionOwnerHref = postVerification.result?.value?.href ?? "";
+  const submissionDocumentTokenStored =
+    postVerification.result?.value?.documentTokenStored === true;
   const observedComposer = observedActive || observedEditor || observedFallback;
   const observedLength = Math.max(
     observedEditor.length,
@@ -303,15 +331,20 @@ export async function submitPrompt(
     prompt,
     commitTimeoutMs,
     logger,
-    deps.baselineTurns ?? undefined,
+    preDispatchBaseline ?? undefined,
     deps.onPromptCommitPending,
-    clicked && !deps.attachmentNames?.length && deps.isSubmissionOwner && submissionOwnerHref
-      ? (baseline) =>
+    clicked &&
+      retainedDraftRecoveryEligible &&
+      submissionOwnerHref &&
+      submissionDocumentToken &&
+      submissionDocumentTokenStored
+      ? () =>
           attemptRetainedDraftPageRetry({
             Runtime: runtime,
             prompt,
-            baseline,
+            baseline: preDispatchBaseline,
             submissionOwnerHref,
+            submissionDocumentToken,
             isSubmissionOwner: deps.isSubmissionOwner!,
           })
       : undefined,
@@ -854,12 +887,14 @@ async function attemptRetainedDraftPageRetry({
   prompt,
   baseline,
   submissionOwnerHref,
+  submissionDocumentToken,
   isSubmissionOwner,
 }: {
   Runtime: ChromeClient["Runtime"];
   prompt: string;
   baseline: number;
   submissionOwnerHref: string;
+  submissionDocumentToken: string;
   isSubmissionOwner: () => Promise<boolean> | boolean;
 }): Promise<RetainedDraftRetryResult> {
   let ownerConfirmed = false;
@@ -875,6 +910,8 @@ async function attemptRetainedDraftPageRetry({
   const script = `(() => {
     const expectedPrompt = ${JSON.stringify(prompt)};
     const expectedOwnerHref = ${JSON.stringify(submissionOwnerHref)};
+    const expectedDocumentToken = ${JSON.stringify(submissionDocumentToken)};
+    const submissionDocumentTokenProperty = ${JSON.stringify(SUBMISSION_DOCUMENT_TOKEN_PROPERTY)};
     const baseline = ${JSON.stringify(baseline)};
     const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
     const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
@@ -954,6 +991,8 @@ async function attemptRetainedDraftPageRetry({
     const draftRetained = !composerCleared;
     const ownerMatched =
       normalizeOwner(location.href) === normalizeOwner(expectedOwnerHref);
+    const documentTokenMatched =
+      document[submissionDocumentTokenProperty] === expectedDocumentToken;
     const gate = {
       submissionCommitted,
       draftRetained,
@@ -965,6 +1004,7 @@ async function attemptRetainedDraftPageRetry({
       baselineKnown: baseline >= 0,
       baselineUnchanged: baseline >= 0 && turnsCount === baseline,
       ownerMatched,
+      documentTokenMatched,
       turnsCount,
     };
     const allowed =
@@ -977,7 +1017,8 @@ async function attemptRetainedDraftPageRetry({
       gate.assistantVisible === false &&
       gate.baselineKnown === true &&
       gate.baselineUnchanged === true &&
-      gate.ownerMatched === true;
+      gate.ownerMatched === true &&
+      gate.documentTokenMatched === true;
     if (!allowed) return { status: 'blocked', reason: 'gate-closed', gate };
     const candidates = sendSelectors.flatMap((selector) =>
       Array.from(document.querySelectorAll(selector)),
@@ -1095,7 +1136,7 @@ async function verifyPromptCommitted(
   logger?: BrowserLogger,
   baselineTurns?: number,
   onCommitPending?: () => Promise<void> | void,
-  retryRetainedDraft?: (baseline: number) => Promise<RetainedDraftRetryResult>,
+  retryRetainedDraft?: () => Promise<RetainedDraftRetryResult>,
 ): Promise<{ turnsCount: number | null; userTurnIndex: number | null }> {
   const deadline = Date.now() + timeoutMs;
   const retainedDraftRetryAt = Date.now() + RETAINED_DRAFT_RETRY_DELAY_MS;
@@ -1244,7 +1285,7 @@ async function verifyPromptCommitted(
     }
     if (retryRetainedDraft && !retainedDraftRetryDecided && Date.now() >= retainedDraftRetryAt) {
       retainedDraftRetryDecided = true;
-      const retry = await retryRetainedDraft(baselineLiteral);
+      const retry = await retryRetainedDraft();
       logger?.(
         `Retained-draft Send retry decision: ${retry.status}${
           retry.reason ? ` (${retry.reason})` : ""
@@ -1355,5 +1396,6 @@ export const __test__ = {
   attemptSendButton,
   composerValueReaderSource: COMPOSER_VALUE_READER_SOURCE,
   sendButtonTimeoutMs,
+  submissionDocumentTokenProperty: SUBMISSION_DOCUMENT_TOKEN_PROPERTY,
   verifyPromptCommitted,
 };

--- a/src/browser/actions/promptComposer.ts
+++ b/src/browser/actions/promptComposer.ts
@@ -23,6 +23,7 @@ const ENTER_KEY_EVENT = {
   nativeVirtualKeyCode: 13,
 } as const;
 const ENTER_KEY_TEXT = "\r";
+const RETAINED_DRAFT_RETRY_DELAY_MS = 2_000;
 
 // Input.insertText gives ProseMirror plain text, but ProseMirror renders each
 // line as a direct block. HTMLElement.innerText inserts an extra newline
@@ -61,6 +62,14 @@ export interface AttachmentReadyExpectation {
 
 type AttachmentReadyInput = string | AttachmentReadyExpectation;
 
+type RetainedDraftRetryStatus = "dispatched" | "blocked" | "unavailable";
+
+interface RetainedDraftRetryResult {
+  status: RetainedDraftRetryStatus;
+  reason?: string;
+  gate?: Record<string, unknown>;
+}
+
 export async function submitPrompt(
   deps: {
     runtime: ChromeClient["Runtime"];
@@ -75,6 +84,7 @@ export async function submitPrompt(
       committedUserTurnIndex: number | null,
     ) => Promise<void> | void;
     onPromptCommitPending?: () => Promise<void> | void;
+    isSubmissionOwner?: () => Promise<boolean> | boolean;
   },
   prompt: string,
   logger: BrowserLogger,
@@ -214,6 +224,7 @@ export async function submitPrompt(
         editorText: readComposerValue(editor),
         fallbackValue: fallback?.value ?? '',
         activeValue: readComposerValue(active),
+        href: typeof location === 'object' && location.href ? location.href : '',
       };
     })()`,
     returnByValue: true,
@@ -221,6 +232,7 @@ export async function submitPrompt(
   const observedEditor = postVerification.result?.value?.editorText ?? "";
   const observedFallback = postVerification.result?.value?.fallbackValue ?? "";
   const observedActive = postVerification.result?.value?.activeValue ?? "";
+  const submissionOwnerHref = postVerification.result?.value?.href ?? "";
   const observedComposer = observedActive || observedEditor || observedFallback;
   const observedLength = Math.max(
     observedEditor.length,
@@ -293,6 +305,16 @@ export async function submitPrompt(
     logger,
     deps.baselineTurns ?? undefined,
     deps.onPromptCommitPending,
+    clicked && !deps.attachmentNames?.length && deps.isSubmissionOwner && submissionOwnerHref
+      ? (baseline) =>
+          attemptRetainedDraftPageRetry({
+            Runtime: runtime,
+            prompt,
+            baseline,
+            submissionOwnerHref,
+            isSubmissionOwner: deps.isSubmissionOwner!,
+          })
+      : undefined,
   );
   await deps.onPromptCommitted?.(committed.turnsCount, committed.userTurnIndex);
   return committed.turnsCount;
@@ -827,6 +849,160 @@ async function attemptSendButton(
   return false;
 }
 
+async function attemptRetainedDraftPageRetry({
+  Runtime,
+  prompt,
+  baseline,
+  submissionOwnerHref,
+  isSubmissionOwner,
+}: {
+  Runtime: ChromeClient["Runtime"];
+  prompt: string;
+  baseline: number;
+  submissionOwnerHref: string;
+  isSubmissionOwner: () => Promise<boolean> | boolean;
+}): Promise<RetainedDraftRetryResult> {
+  let ownerConfirmed = false;
+  try {
+    ownerConfirmed = (await isSubmissionOwner()) === true;
+  } catch {
+    return { status: "blocked", reason: "target-owner-check-failed" };
+  }
+  if (!ownerConfirmed) {
+    return { status: "blocked", reason: "target-owner-mismatch" };
+  }
+
+  const script = `(() => {
+    const expectedPrompt = ${JSON.stringify(prompt)};
+    const expectedOwnerHref = ${JSON.stringify(submissionOwnerHref)};
+    const baseline = ${JSON.stringify(baseline)};
+    const inputSelectors = ${JSON.stringify(INPUT_SELECTORS)};
+    const sendSelectors = ${JSON.stringify(SEND_BUTTON_SELECTORS)};
+    const stopSelector = ${JSON.stringify(STOP_BUTTON_SELECTOR)};
+    ${COMPOSER_VALUE_READER_SOURCE}
+    const normalizeComposer = (value) => String(value ?? '')
+      .replace(/\\r\\n?/g, '\\n')
+      .replace(/\\u00a0/g, ' ');
+    const normalizeTurn = (value) => {
+      let text = String(value ?? '').toLowerCase();
+      text = text.replace(/\`\`\`[^\\n]*\\n([\\s\\S]*?)\`\`\`/g, ' $1 ');
+      text = text.replace(/\`\`\`/g, ' ');
+      text = text.replace(/\`([^\`]*)\`/g, '$1');
+      return text.replace(/\\s+/g, ' ').trim();
+    };
+    const normalizeOwner = (value) => {
+      try {
+        const url = new URL(String(value ?? ''), location.href);
+        return url.origin + url.pathname.replace(/\\/$/, '');
+      } catch {
+        return '';
+      }
+    };
+    const isVisible = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      const style = window.getComputedStyle(node);
+      return style.display !== 'none' && style.visibility !== 'hidden';
+    };
+    const isEnabled = (node) => {
+      if (!(node instanceof HTMLElement)) return false;
+      const style = window.getComputedStyle(node);
+      return !(
+        node.hasAttribute('disabled') ||
+        node.getAttribute('aria-disabled') === 'true' ||
+        node.getAttribute('data-disabled') === 'true' ||
+        style.pointerEvents === 'none' ||
+        style.display === 'none'
+      );
+    };
+    const roleOf = (node) => String(
+      node?.getAttribute?.('data-message-author-role') ||
+      node?.getAttribute?.('data-turn') ||
+      node?.dataset?.turn ||
+      node?.querySelector?.('[data-message-author-role], [data-turn]')?.getAttribute?.(
+        'data-message-author-role',
+      ) ||
+      node?.querySelector?.('[data-message-author-role], [data-turn]')?.getAttribute?.('data-turn') ||
+      '',
+    ).toLowerCase();
+    const articles = ${buildConversationTurnListExpression()};
+    const turnsCount = articles.length;
+    const newArticles = baseline >= 0 ? articles.slice(baseline) : articles;
+    const userMatched = normalizeTurn(expectedPrompt).length > 0 && newArticles.some((node) => {
+      if (roleOf(node) !== 'user') return false;
+      const roleNode = node?.getAttribute?.('data-message-author-role') === 'user' ||
+        node?.getAttribute?.('data-turn') === 'user'
+        ? node
+        : node?.querySelector?.('[data-message-author-role="user"], [data-turn="user"]');
+      const messageNode = roleNode?.querySelector?.('.whitespace-pre-wrap') || roleNode;
+      return normalizeTurn(messageNode?.innerText || messageNode?.textContent || '') ===
+        normalizeTurn(expectedPrompt);
+    });
+    const hasNewTurn = baseline >= 0 && turnsCount > baseline;
+    const submissionCommitted = hasNewTurn && userMatched;
+    const assistantVisible = baseline < 0 || newArticles.some((node) => roleOf(node) === 'assistant');
+    const stopVisible = Array.from(document.querySelectorAll(stopSelector)).some(isVisible);
+    const inputs = inputSelectors
+      .map((selector) => document.querySelector(selector))
+      .filter((node) => Boolean(node));
+    const active = inputs.find((node) => isVisible(node)) || inputs[0] || null;
+    const observed = readComposerValue(active);
+    const composerMatchesPrompt =
+      normalizeComposer(observed) === normalizeComposer(expectedPrompt);
+    const composerCleared = !String(observed).trim();
+    const draftRetained = !composerCleared;
+    const ownerMatched =
+      normalizeOwner(location.href) === normalizeOwner(expectedOwnerHref);
+    const gate = {
+      submissionCommitted,
+      draftRetained,
+      composerMatchesPrompt,
+      hasNewTurn,
+      userMatched,
+      stopVisible,
+      assistantVisible,
+      baselineKnown: baseline >= 0,
+      baselineUnchanged: baseline >= 0 && turnsCount === baseline,
+      ownerMatched,
+      turnsCount,
+    };
+    const allowed =
+      gate.submissionCommitted === false &&
+      gate.draftRetained === true &&
+      gate.composerMatchesPrompt === true &&
+      gate.hasNewTurn === false &&
+      gate.userMatched === false &&
+      gate.stopVisible === false &&
+      gate.assistantVisible === false &&
+      gate.baselineKnown === true &&
+      gate.baselineUnchanged === true &&
+      gate.ownerMatched === true;
+    if (!allowed) return { status: 'blocked', reason: 'gate-closed', gate };
+    const candidates = sendSelectors.flatMap((selector) =>
+      Array.from(document.querySelectorAll(selector)),
+    );
+    const button = candidates.find((node) => isVisible(node) && isEnabled(node)) || null;
+    if (!button) return { status: 'unavailable', reason: 'send-button-unavailable', gate };
+    button.click();
+    return { status: 'dispatched', gate };
+  })()`;
+  const result = await Runtime.evaluate({ expression: script, returnByValue: true }).catch(
+    () => null,
+  );
+  if (!result) {
+    return { status: "blocked", reason: "retry-evidence-unavailable" };
+  }
+  const value = result.result?.value as RetainedDraftRetryResult | undefined;
+  if (
+    !value ||
+    (value.status !== "dispatched" && value.status !== "blocked" && value.status !== "unavailable")
+  ) {
+    return { status: "blocked", reason: "retry-evidence-unavailable" };
+  }
+  return value;
+}
+
 async function assertComposerUnchanged(
   Runtime: ChromeClient["Runtime"],
   expectedPrompt: string,
@@ -919,8 +1095,10 @@ async function verifyPromptCommitted(
   logger?: BrowserLogger,
   baselineTurns?: number,
   onCommitPending?: () => Promise<void> | void,
+  retryRetainedDraft?: (baseline: number) => Promise<RetainedDraftRetryResult>,
 ): Promise<{ turnsCount: number | null; userTurnIndex: number | null }> {
   const deadline = Date.now() + timeoutMs;
+  const retainedDraftRetryAt = Date.now() + RETAINED_DRAFT_RETRY_DELAY_MS;
   const encodedPrompt = JSON.stringify(prompt.trim());
   const primarySelectorLiteral = JSON.stringify(PROMPT_PRIMARY_SELECTOR);
   const fallbackSelectorLiteral = JSON.stringify(PROMPT_FALLBACK_SELECTOR);
@@ -1030,7 +1208,7 @@ async function verifyPromptCommitted(
 	      lastMatched,
 	      lastUserTurnAvailable: userTurnTexts.length > 0,
 	      hasNewTurn,
-	      stopVisible,
+      stopVisible,
       assistantVisible,
       composerCleared,
       inConversation,
@@ -1044,6 +1222,7 @@ async function verifyPromptCommitted(
 
   let lastProbe: CommitProbeState | undefined;
   let nextPendingCheckAt = 0;
+  let retainedDraftRetryDecided = false;
   while (Date.now() < deadline) {
     const { result } = await Runtime.evaluate({ expression: script, returnByValue: true });
     const info = result.value as CommitProbeState | undefined;
@@ -1062,6 +1241,16 @@ async function verifyPromptCommitted(
             ? userTurnIndex
             : null,
       };
+    }
+    if (retryRetainedDraft && !retainedDraftRetryDecided && Date.now() >= retainedDraftRetryAt) {
+      retainedDraftRetryDecided = true;
+      const retry = await retryRetainedDraft(baselineLiteral);
+      logger?.(
+        `Retained-draft Send retry decision: ${retry.status}${
+          retry.reason ? ` (${retry.reason})` : ""
+        }`,
+      );
+      continue;
     }
     if (onCommitPending && Date.now() >= nextPendingCheckAt) {
       nextPendingCheckAt = Date.now() + 500;
@@ -1162,6 +1351,7 @@ function normalizeComposerText(value: string): string {
 
 // biome-ignore lint/style/useNamingConvention: test-only export used in vitest suite
 export const __test__ = {
+  attemptRetainedDraftPageRetry,
   attemptSendButton,
   composerValueReaderSource: COMPOSER_VALUE_READER_SOURCE,
   sendButtonTimeoutMs,

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1663,6 +1663,12 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
         );
       }
       let baselineTurns = await readConversationTurnCount(Runtime, logger);
+      const submissionTargetId = lastTargetId;
+      const isSubmissionOwner = async (): Promise<boolean> => {
+        if (!submissionTargetId || lastTargetId !== submissionTargetId) return false;
+        const { targetInfo } = await Target.getTargetInfo({ targetId: submissionTargetId });
+        return targetInfo.targetId === submissionTargetId && targetInfo.type === "page";
+      };
       // Learned: return baselineTurns so assistant polling can ignore earlier content.
       const providerState: Record<string, unknown> = {
         runtime: Runtime,
@@ -1697,6 +1703,7 @@ export async function runBrowserMode(options: BrowserRunOptions): Promise<Browse
             submissionCommitted: false,
             dispatchAttempted: true,
           }),
+        isSubmissionOwner,
       };
       const deepResearchTargetBaseline =
         deepResearch && client
@@ -3423,6 +3430,12 @@ async function runRemoteBrowserMode(
         );
       }
       let baselineTurns = await readConversationTurnCount(Runtime, logger);
+      const submissionTargetId = remoteTargetId;
+      const isSubmissionOwner = async (): Promise<boolean> => {
+        if (!submissionTargetId || remoteTargetId !== submissionTargetId) return false;
+        const { targetInfo } = await Target.getTargetInfo({ targetId: submissionTargetId });
+        return targetInfo.targetId === submissionTargetId && targetInfo.type === "page";
+      };
       const providerState: Record<string, unknown> = {
         runtime: Runtime,
         input: Input,
@@ -3456,6 +3469,7 @@ async function runRemoteBrowserMode(
             submissionCommitted: false,
             dispatchAttempted: true,
           }),
+        isSubmissionOwner,
       };
       const deepResearchTargetBaseline =
         deepResearch && client

--- a/src/browser/providers/chatgptDomProvider.ts
+++ b/src/browser/providers/chatgptDomProvider.ts
@@ -20,6 +20,7 @@ interface ChatgptDomProviderState {
     committedUserTurnIndex: number | null,
   ) => Promise<void> | void;
   onPromptCommitPending?: () => Promise<void> | void;
+  isSubmissionOwner?: () => Promise<boolean> | boolean;
 }
 
 function requireState(ctx: ProviderDomFlowContext): ChatgptDomProviderState {
@@ -52,6 +53,7 @@ async function submitPromptViaAdapter(ctx: ProviderDomFlowContext): Promise<void
       onPromptDispatched: state.onPromptDispatched,
       onPromptCommitted: state.onPromptCommitted,
       onPromptCommitPending: state.onPromptCommitPending,
+      isSubmissionOwner: state.isSubmissionOwner,
     },
     ctx.prompt,
     state.logger,

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -9,6 +9,127 @@ import {
   CONVERSATION_TURN_SELECTOR,
 } from "../../src/browser/constants.js";
 
+class RetryGateFakeElement {
+  readonly dataset: Record<string, string> = {};
+  readonly childNodes: RetryGateFakeElement[] = [];
+  readonly children: RetryGateFakeElement[] = [];
+  readonly classList = { contains: () => false };
+  readonly click = vi.fn();
+  innerText = "";
+  textContent = "";
+
+  constructor(readonly attributes: Record<string, string> = {}) {}
+
+  getAttribute(name: string) {
+    return this.attributes[name] ?? null;
+  }
+
+  hasAttribute(name: string) {
+    return name in this.attributes;
+  }
+
+  getBoundingClientRect() {
+    return { width: 10, height: 10 };
+  }
+
+  querySelector(selector: string) {
+    return selector === ".whitespace-pre-wrap" ? this : null;
+  }
+}
+
+class RetryGateFakeTextArea extends RetryGateFakeElement {
+  value = "";
+}
+
+async function runRetainedDraftRetryGate({
+  baseline = 0,
+  composerValue = "hello",
+  currentDocumentToken = "document-token",
+  expectedDocumentToken = "document-token",
+  href = "https://chatgpt.com/",
+  stopVisible = false,
+  turns = [],
+  isSubmissionOwner = () => true,
+}: {
+  baseline?: number;
+  composerValue?: string;
+  currentDocumentToken?: string | null;
+  expectedDocumentToken?: string;
+  href?: string;
+  stopVisible?: boolean;
+  turns?: Array<{ role: "assistant" | "user"; text: string }>;
+  isSubmissionOwner?: () => boolean | Promise<boolean>;
+} = {}) {
+  const composer = new RetryGateFakeTextArea();
+  composer.value = composerValue;
+  const turnNodes = turns.map(({ role, text }) => {
+    const node = new RetryGateFakeElement({ "data-message-author-role": role });
+    node.innerText = text;
+    node.textContent = text;
+    return node;
+  });
+  const stopButton = new RetryGateFakeElement();
+  const sendButton = new RetryGateFakeElement();
+  const fakeDocument = {
+    querySelector: () => composer,
+    querySelectorAll: (selector: string) => {
+      if (selector === CONVERSATION_TURN_CONTAINER_SELECTOR) return turnNodes;
+      if (selector === CONVERSATION_TURN_SELECTOR) return turnNodes;
+      if (selector === '[data-testid="stop-button"]') return stopVisible ? [stopButton] : [];
+      if (selector.includes("send") || selector.includes('type="submit"')) {
+        return [sendButton];
+      }
+      return [];
+    },
+  };
+  if (currentDocumentToken !== null) {
+    Object.defineProperty(fakeDocument, promptComposer.submissionDocumentTokenProperty, {
+      value: currentDocumentToken,
+    });
+  }
+  const browserWindow = {
+    getComputedStyle: () => ({
+      display: "block",
+      visibility: "visible",
+      pointerEvents: "auto",
+    }),
+  };
+  const location = { href };
+  const runtime = {
+    evaluate: vi.fn(async ({ expression }: { expression: string }) => ({
+      result: {
+        value: Function(
+          "document",
+          "window",
+          "location",
+          "HTMLElement",
+          "HTMLTextAreaElement",
+          "Node",
+          "URL",
+          `return ${expression}`,
+        )(
+          fakeDocument,
+          browserWindow,
+          location,
+          RetryGateFakeElement,
+          RetryGateFakeTextArea,
+          { TEXT_NODE: 3 },
+          URL,
+        ),
+      },
+    })),
+  };
+  const result = await promptComposer.attemptRetainedDraftPageRetry({
+    Runtime: runtime as never,
+    prompt: "hello",
+    baseline,
+    submissionOwnerHref: href,
+    submissionDocumentToken: expectedDocumentToken,
+    isSubmissionOwner,
+  });
+  return { result, runtime, sendButton };
+}
+
 describe("promptComposer", () => {
   test("reconstructs exact multiline text from ProseMirror blocks", () => {
     class FakeNode {
@@ -614,7 +735,7 @@ describe("promptComposer", () => {
     expect(actions).toEqual(["send-click"]);
   });
 
-  test("retries one retained draft through an atomic page-side gate", async () => {
+  test("retries one retained draft through an atomic page-side gate without Enter", async () => {
     vi.useFakeTimers();
     try {
       let retryDispatched = false;
@@ -636,6 +757,7 @@ describe("promptComposer", () => {
                   fallbackValue: "",
                   activeValue: "hello",
                   href: "https://chatgpt.com/",
+                  documentTokenStored: true,
                 },
               },
             };
@@ -658,6 +780,7 @@ describe("promptComposer", () => {
                     baselineKnown: true,
                     baselineUnchanged: true,
                     ownerMatched: true,
+                    documentTokenMatched: true,
                   },
                 },
               },
@@ -725,6 +848,162 @@ describe("promptComposer", () => {
     }
   });
 
+  test("does not let a post-dispatch fallback count authorize retry", async () => {
+    vi.useFakeTimers();
+    try {
+      let commitProbes = 0;
+      let fallbackCountReads = 0;
+      let sendDispatched = false;
+      const isSubmissionOwner = vi.fn(() => true);
+      const runtime = {
+        evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+          if (expression.includes("document.readyState")) {
+            return { result: { value: { ready: true, composer: true, fileInput: false } } };
+          }
+          if (expression.includes("focused: true")) {
+            return { result: { value: { focused: true } } };
+          }
+          if (expression.includes("editorText")) {
+            return {
+              result: {
+                value: {
+                  editorText: "hello",
+                  fallbackValue: "",
+                  activeValue: "hello",
+                  href: "https://chatgpt.com/",
+                  documentTokenStored: true,
+                },
+              },
+            };
+          }
+          if (expression.includes("button.scrollIntoView")) {
+            sendDispatched = true;
+            return { result: { value: { status: "clicked" } } };
+          }
+          if (expression.trimEnd().endsWith(").length")) {
+            fallbackCountReads += 1;
+            return { result: { value: 1 } };
+          }
+          commitProbes += 1;
+          const committed = commitProbes >= 25;
+          return {
+            result: {
+              value: {
+                baseline: 1,
+                turnsCount: committed ? 2 : 1,
+                userMatched: committed,
+                matchedUserTurnIndex: committed ? 1 : null,
+                lastMatched: committed,
+                hasNewTurn: committed,
+                stopVisible: committed,
+                assistantVisible: false,
+                composerCleared: committed,
+                inConversation: committed,
+                editorValue: committed ? "" : "hello",
+              },
+            },
+          };
+        }),
+      };
+      const input = { insertText: vi.fn(), dispatchKeyEvent: vi.fn() };
+      const logger = Object.assign(vi.fn(), { verbose: false });
+
+      const result = submitPrompt(
+        {
+          runtime: runtime as never,
+          input: input as never,
+          baselineTurns: null,
+          isSubmissionOwner,
+        },
+        "hello",
+        logger as never,
+      );
+      const assertion = expect(result).resolves.toBe(2);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await assertion;
+
+      expect(sendDispatched).toBe(true);
+      expect(fallbackCountReads).toBe(1);
+      expect(isSubmissionOwner).not.toHaveBeenCalled();
+      expect(runtime.evaluate).not.toHaveBeenCalledWith(
+        expect.objectContaining({ expression: expect.stringContaining("expectedDocumentToken") }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("excludes attachment submissions from retained-draft recovery", async () => {
+    let postVerificationExpression = "";
+    const isSubmissionOwner = vi.fn(() => true);
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+        if (expression.includes("document.readyState")) {
+          return { result: { value: { ready: true, composer: true, fileInput: false } } };
+        }
+        if (expression.includes("focused: true")) {
+          return { result: { value: { focused: true } } };
+        }
+        if (expression.includes("editorText")) {
+          postVerificationExpression = expression;
+          return {
+            result: {
+              value: {
+                editorText: "hello",
+                fallbackValue: "",
+                activeValue: "hello",
+                href: "https://chatgpt.com/",
+                documentTokenStored: true,
+              },
+            },
+          };
+        }
+        if (expression.includes("button.scrollIntoView")) {
+          return { result: { value: { status: "clicked" } } };
+        }
+        if (expression.includes("const expected =")) {
+          return { result: { value: true } };
+        }
+        return {
+          result: {
+            value: {
+              baseline: 0,
+              turnsCount: 1,
+              userMatched: true,
+              matchedUserTurnIndex: 0,
+              lastMatched: true,
+              hasNewTurn: true,
+              stopVisible: true,
+              assistantVisible: false,
+              composerCleared: true,
+              inConversation: true,
+            },
+          },
+        };
+      }),
+    };
+    const input = { insertText: vi.fn(), dispatchKeyEvent: vi.fn() };
+    const logger = Object.assign(vi.fn(), { verbose: false });
+
+    await expect(
+      submitPrompt(
+        {
+          runtime: runtime as never,
+          input: input as never,
+          attachmentNames: ["oracle-attach-verify.txt"],
+          baselineTurns: 0,
+          isSubmissionOwner,
+        },
+        "hello",
+        logger as never,
+      ),
+    ).resolves.toBe(1);
+
+    expect(postVerificationExpression).toContain("const submissionDocumentToken = null");
+    expect(isSubmissionOwner).not.toHaveBeenCalled();
+    expect(input.dispatchKeyEvent).not.toHaveBeenCalled();
+  });
+
   test("dispatches at most one retained-draft retry while commit remains absent", async () => {
     vi.useFakeTimers();
     try {
@@ -773,90 +1052,14 @@ describe("promptComposer", () => {
   });
 
   test("cancels the retry when the first click commits during the atomic recheck", async () => {
-    class FakeElement {
-      readonly dataset: Record<string, string> = {};
-      readonly childNodes: FakeElement[] = [];
-      readonly children: FakeElement[] = [];
-      readonly classList = { contains: () => false };
-      readonly click = vi.fn();
-      innerText = "";
-      textContent = "";
-
-      constructor(readonly attributes: Record<string, string> = {}) {}
-
-      getAttribute(name: string) {
-        return this.attributes[name] ?? null;
-      }
-
-      hasAttribute(name: string) {
-        return name in this.attributes;
-      }
-
-      getBoundingClientRect() {
-        return { width: 10, height: 10 };
-      }
-
-      querySelector(selector: string) {
-        return selector === ".whitespace-pre-wrap" ? this : null;
-      }
-    }
-    class FakeTextArea extends FakeElement {
-      value = "";
-    }
-
     // This DOM is the delayed-first-click state visible at the recovery
     // boundary: the original user turn and streaming signal have just appeared.
-    const composer = new FakeTextArea();
-    const userTurn = new FakeElement({ "data-message-author-role": "user" });
-    userTurn.innerText = "hello";
-    userTurn.textContent = "hello";
-    const stopButton = new FakeElement();
-    const sendButton = new FakeElement();
-    const document = {
-      querySelector: () => composer,
-      querySelectorAll: (selector: string) => {
-        if (selector === CONVERSATION_TURN_CONTAINER_SELECTOR) return [userTurn];
-        if (selector === '[data-testid="stop-button"]') return [stopButton];
-        if (selector.includes("send") || selector.includes('type="submit"')) {
-          return [sendButton];
-        }
-        return [];
-      },
-    };
-    const browserWindow = {
-      getComputedStyle: () => ({
-        display: "block",
-        visibility: "visible",
-        pointerEvents: "auto",
-      }),
-    };
-    const location = { href: "https://chatgpt.com/" };
-    const runtime = {
-      evaluate: vi.fn(async ({ expression }: { expression: string }) => ({
-        result: {
-          value: Function(
-            "document",
-            "window",
-            "location",
-            "HTMLElement",
-            "HTMLTextAreaElement",
-            "Node",
-            "URL",
-            `return ${expression}`,
-          )(document, browserWindow, location, FakeElement, FakeTextArea, { TEXT_NODE: 3 }, URL),
-        },
-      })),
-    };
+    const { result, runtime, sendButton } = await runRetainedDraftRetryGate({
+      stopVisible: true,
+      turns: [{ role: "user", text: "hello" }],
+    });
 
-    await expect(
-      promptComposer.attemptRetainedDraftPageRetry({
-        Runtime: runtime as never,
-        prompt: "hello",
-        baseline: 0,
-        submissionOwnerHref: location.href,
-        isSubmissionOwner: () => true,
-      }),
-    ).resolves.toMatchObject({
+    expect(result).toMatchObject({
       status: "blocked",
       reason: "gate-closed",
       gate: {
@@ -870,6 +1073,41 @@ describe("promptComposer", () => {
     expect(sendButton.click).not.toHaveBeenCalled();
   });
 
+  test.each([
+    ["unknown pre-dispatch baseline", { baseline: -1 }, "baselineKnown"],
+    [
+      "changed pre-dispatch baseline",
+      { turns: [{ role: "user" as const, text: "different" }] },
+      "baselineUnchanged",
+    ],
+    ["composer mismatch", { composerValue: "changed" }, "composerMatchesPrompt"],
+  ])("blocks retained-draft retry for %s", async (_label, scenario, deniedField) => {
+    const { result, sendButton } = await runRetainedDraftRetryGate(scenario);
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      reason: "gate-closed",
+      gate: { [deniedField]: false },
+    });
+    expect(sendButton.click).not.toHaveBeenCalled();
+  });
+
+  test("blocks a same-target same-href replacement document", async () => {
+    const { result, sendButton } = await runRetainedDraftRetryGate({
+      currentDocumentToken: null,
+    });
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      reason: "gate-closed",
+      gate: {
+        ownerMatched: true,
+        documentTokenMatched: false,
+      },
+    });
+    expect(sendButton.click).not.toHaveBeenCalled();
+  });
+
   test("fails the retained-draft retry closed when target ownership changes", async () => {
     const runtime = { evaluate: vi.fn() };
 
@@ -879,10 +1117,24 @@ describe("promptComposer", () => {
         prompt: "hello",
         baseline: 0,
         submissionOwnerHref: "https://chatgpt.com/",
+        submissionDocumentToken: "document-token",
         isSubmissionOwner: () => false,
       }),
     ).resolves.toEqual({ status: "blocked", reason: "target-owner-mismatch" });
     expect(runtime.evaluate).not.toHaveBeenCalled();
+  });
+
+  test("fails the retained-draft retry closed when the owner probe errors", async () => {
+    const ownerError = new Error("owner probe unavailable");
+    const { result, runtime, sendButton } = await runRetainedDraftRetryGate({
+      isSubmissionOwner: () => {
+        throw ownerError;
+      },
+    });
+
+    expect(result).toEqual({ status: "blocked", reason: "target-owner-check-failed" });
+    expect(runtime.evaluate).not.toHaveBeenCalled();
+    expect(sendButton.click).not.toHaveBeenCalled();
   });
 
   test("refuses to send when external input mutates the composer", async () => {

--- a/tests/browser/promptComposer.test.ts
+++ b/tests/browser/promptComposer.test.ts
@@ -614,6 +614,277 @@ describe("promptComposer", () => {
     expect(actions).toEqual(["send-click"]);
   });
 
+  test("retries one retained draft through an atomic page-side gate", async () => {
+    vi.useFakeTimers();
+    try {
+      let retryDispatched = false;
+      let retryChecks = 0;
+      const isSubmissionOwner = vi.fn(() => true);
+      const runtime = {
+        evaluate: vi.fn(async ({ expression }: { expression: string }) => {
+          if (expression.includes("document.readyState")) {
+            return { result: { value: { ready: true, composer: true, fileInput: false } } };
+          }
+          if (expression.includes("focused: true")) {
+            return { result: { value: { focused: true } } };
+          }
+          if (expression.includes("editorText")) {
+            return {
+              result: {
+                value: {
+                  editorText: "hello",
+                  fallbackValue: "",
+                  activeValue: "hello",
+                  href: "https://chatgpt.com/",
+                },
+              },
+            };
+          }
+          if (expression.includes("expectedOwnerHref")) {
+            retryChecks += 1;
+            retryDispatched = true;
+            return {
+              result: {
+                value: {
+                  status: "dispatched",
+                  gate: {
+                    submissionCommitted: false,
+                    draftRetained: true,
+                    composerMatchesPrompt: true,
+                    hasNewTurn: false,
+                    userMatched: false,
+                    stopVisible: false,
+                    assistantVisible: false,
+                    baselineKnown: true,
+                    baselineUnchanged: true,
+                    ownerMatched: true,
+                  },
+                },
+              },
+            };
+          }
+          if (expression.includes("button.scrollIntoView")) {
+            return { result: { value: { status: "clicked" } } };
+          }
+          return {
+            result: {
+              value: retryDispatched
+                ? {
+                    baseline: 0,
+                    turnsCount: 2,
+                    userMatched: true,
+                    matchedUserTurnIndex: 0,
+                    lastMatched: true,
+                    hasNewTurn: true,
+                    stopVisible: true,
+                    assistantVisible: true,
+                    composerCleared: true,
+                    composerMatchesPrompt: false,
+                    inConversation: true,
+                  }
+                : {
+                    baseline: 0,
+                    turnsCount: 0,
+                    userMatched: false,
+                    matchedUserTurnIndex: null,
+                    lastMatched: false,
+                    hasNewTurn: false,
+                    stopVisible: false,
+                    assistantVisible: false,
+                    composerCleared: false,
+                    composerMatchesPrompt: true,
+                    inConversation: false,
+                  },
+            },
+          };
+        }),
+      };
+      const input = { insertText: vi.fn(), dispatchKeyEvent: vi.fn() };
+      const logger = Object.assign(vi.fn(), { verbose: false });
+
+      const result = submitPrompt(
+        {
+          runtime: runtime as never,
+          input: input as never,
+          baselineTurns: 0,
+          isSubmissionOwner,
+        },
+        "hello",
+        logger as never,
+      );
+      const assertion = expect(result).resolves.toBe(2);
+      await vi.advanceTimersByTimeAsync(3_000);
+      await assertion;
+
+      expect(isSubmissionOwner).toHaveBeenCalledTimes(1);
+      expect(retryChecks).toBe(1);
+      expect(input.dispatchKeyEvent).not.toHaveBeenCalled();
+      expect(logger).toHaveBeenCalledWith("Retained-draft Send retry decision: dispatched");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("dispatches at most one retained-draft retry while commit remains absent", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtime = {
+        evaluate: vi.fn(async () => ({
+          result: {
+            value: {
+              baseline: 0,
+              turnsCount: 0,
+              userMatched: false,
+              lastMatched: false,
+              hasNewTurn: false,
+              stopVisible: false,
+              assistantVisible: false,
+              composerCleared: false,
+              inConversation: false,
+              editorValue: "hello",
+            },
+          },
+        })),
+      };
+      const retry = vi.fn(async () => ({ status: "dispatched" as const }));
+
+      const promise = promptComposer.verifyPromptCommitted(
+        runtime as never,
+        "hello",
+        2_250,
+        undefined,
+        0,
+        undefined,
+        retry,
+      );
+      const assertion = expect(promise).rejects.toMatchObject({
+        details: expect.objectContaining({
+          code: "prompt-commit-timeout",
+          submissionCommitted: false,
+        }),
+      });
+      await vi.advanceTimersByTimeAsync(2_500);
+      await assertion;
+
+      expect(retry).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("cancels the retry when the first click commits during the atomic recheck", async () => {
+    class FakeElement {
+      readonly dataset: Record<string, string> = {};
+      readonly childNodes: FakeElement[] = [];
+      readonly children: FakeElement[] = [];
+      readonly classList = { contains: () => false };
+      readonly click = vi.fn();
+      innerText = "";
+      textContent = "";
+
+      constructor(readonly attributes: Record<string, string> = {}) {}
+
+      getAttribute(name: string) {
+        return this.attributes[name] ?? null;
+      }
+
+      hasAttribute(name: string) {
+        return name in this.attributes;
+      }
+
+      getBoundingClientRect() {
+        return { width: 10, height: 10 };
+      }
+
+      querySelector(selector: string) {
+        return selector === ".whitespace-pre-wrap" ? this : null;
+      }
+    }
+    class FakeTextArea extends FakeElement {
+      value = "";
+    }
+
+    // This DOM is the delayed-first-click state visible at the recovery
+    // boundary: the original user turn and streaming signal have just appeared.
+    const composer = new FakeTextArea();
+    const userTurn = new FakeElement({ "data-message-author-role": "user" });
+    userTurn.innerText = "hello";
+    userTurn.textContent = "hello";
+    const stopButton = new FakeElement();
+    const sendButton = new FakeElement();
+    const document = {
+      querySelector: () => composer,
+      querySelectorAll: (selector: string) => {
+        if (selector === CONVERSATION_TURN_CONTAINER_SELECTOR) return [userTurn];
+        if (selector === '[data-testid="stop-button"]') return [stopButton];
+        if (selector.includes("send") || selector.includes('type="submit"')) {
+          return [sendButton];
+        }
+        return [];
+      },
+    };
+    const browserWindow = {
+      getComputedStyle: () => ({
+        display: "block",
+        visibility: "visible",
+        pointerEvents: "auto",
+      }),
+    };
+    const location = { href: "https://chatgpt.com/" };
+    const runtime = {
+      evaluate: vi.fn(async ({ expression }: { expression: string }) => ({
+        result: {
+          value: Function(
+            "document",
+            "window",
+            "location",
+            "HTMLElement",
+            "HTMLTextAreaElement",
+            "Node",
+            "URL",
+            `return ${expression}`,
+          )(document, browserWindow, location, FakeElement, FakeTextArea, { TEXT_NODE: 3 }, URL),
+        },
+      })),
+    };
+
+    await expect(
+      promptComposer.attemptRetainedDraftPageRetry({
+        Runtime: runtime as never,
+        prompt: "hello",
+        baseline: 0,
+        submissionOwnerHref: location.href,
+        isSubmissionOwner: () => true,
+      }),
+    ).resolves.toMatchObject({
+      status: "blocked",
+      reason: "gate-closed",
+      gate: {
+        submissionCommitted: true,
+        hasNewTurn: true,
+        userMatched: true,
+        stopVisible: true,
+      },
+    });
+    expect(runtime.evaluate).toHaveBeenCalledTimes(1);
+    expect(sendButton.click).not.toHaveBeenCalled();
+  });
+
+  test("fails the retained-draft retry closed when target ownership changes", async () => {
+    const runtime = { evaluate: vi.fn() };
+
+    await expect(
+      promptComposer.attemptRetainedDraftPageRetry({
+        Runtime: runtime as never,
+        prompt: "hello",
+        baseline: 0,
+        submissionOwnerHref: "https://chatgpt.com/",
+        isSubmissionOwner: () => false,
+      }),
+    ).resolves.toEqual({ status: "blocked", reason: "target-owner-mismatch" });
+    expect(runtime.evaluate).not.toHaveBeenCalled();
+  });
+
   test("refuses to send when external input mutates the composer", async () => {
     let composerRead = 0;
     const runtime = {


### PR DESCRIPTION
Related to #1.

## Scope

This candidate contains only the retained-draft Send recovery and its focused evidence. It does not include the earlier exploratory Enter, window, follow-up, or refactor patches.

After a nominal coordinate Send attempt, Oracle waits for normal commit evidence. If no commit appears, it permits one page-side Send dispatch only when a fresh, same-task browser evaluation proves all of the following immediately before `button.click()`:

```text
submissionCommitted == false
draftRetained == true
composerMatchesPrompt == true
hasNewTurn == false
userMatched == false
stopVisible == false
assistantVisible == false
baselineKnown == true
baselineUnchanged == true
ownerMatched == true
```

The captured CDP target must also still be the original submission owner. Missing evidence closes the gate. Attachments are excluded, and this recovery path never uses Enter.

## Duplicate prevention

The final gate read and the optional page-side `button.click()` occur in the same synchronous page evaluation. The timeout probe is not reused. The delayed-first-commit test executes that page script against a DOM in which the first user turn and streaming evidence appear at the recovery boundary; the gate reports committed/blocked and the second Send click count remains zero. A separate test proves the retry callback can dispatch at most once even if commit remains absent.

## Windows live evidence

Both runs used the candidate build, the dedicated authenticated Chrome for Testing profile, direct CDP, GPT-5.6 Sol with Pro selected, no API fallback, and no Answer-now action.

### Case A — forced first-click no-op

- Exact target prepared with a capture-phase test interceptor.
- First trusted coordinate click: intercepted once and intentionally ignored.
- Oracle decision: `Retained-draft Send retry decision: dispatched`.
- Page-side recovery clicks: exactly 1.
- Exact matching user turns after a 3-second stability window: 1.
- Composer cleared; assistant turn appeared; Pro response captured.
- Session receipt: `promptSubmitted:true`, `proTurnCommitted:true`.

### Case B — delayed first-click commit

- First trusted coordinate click: intercepted once.
- The same page button was released 1709 ms later, near the 2000 ms recovery boundary.
- Oracle decision: `Retained-draft Send retry decision: blocked (gate-closed)`.
- Delayed first-dispatch clicks: exactly 1; recovery clicks: 0.
- Exact matching user turns: 1.
- Composer cleared; assistant turn appeared; Pro response captured.
- Session receipt: `promptSubmitted:true`, `proTurnCommitted:true`.

The forced behavior lived only in an untracked local harness that was deleted after evidence capture; no test hook or fault-injection path is shipped.

## `Session with given id not found.`

The historical failure is Chromium DevTools error `-32001`: Chromium's DevTools dispatcher could not find the flattened child CDP session named in a protocol message. It is not an Oracle application-session ID, coding-agent terminal session, or MCP session. The exact CDP command was not traced because that historical run did not retain protocol-level command tracing.

This remains separate from the Send candidate. A stale page session must be discarded; recovery should enumerate targets from the browser-level connection and attach fresh by durable target/conversation identity. Current code already rejects response recovery when `proTurnCommitted:false`.

## Verification

- Focused prompt/session/reattach suite: 10 files, 169 tests passed.
- Candidate prompt composer suite: 22 tests passed.
- `pnpm run lint`: passed (includes typecheck).
- `pnpm run build`: passed on Windows.
- Dedicated browser smoke: 2/2 cold starts passed, authenticated and prompt-ready, no prompt submitted.
- Changed-file format check: passed.
- Full suite executed: 1750 passed, 40 skipped, 12 failed in six untouched platform-sensitive files. Local Windows failures are POSIX mode assertions (2), symlink creation without Developer Mode (6), macOS path expectations (2), and LF-only string expectations under a CRLF checkout (2). No failure touches this diff.
- Repository-wide `format:check` is not claimed locally: the Windows checkout reports CRLF formatting differences across 408 unchanged files.

## Remaining edge cases

- A first dispatch accepted server-side but still exposing no DOM/streaming evidence at the final synchronous gate cannot be distinguished from a true no-op without a server idempotency key. The retry remains bounded to one and fail-closed on every observable ambiguity.
- A page-side programmatic click still depends on the current ChatGPT UI accepting that dispatch mechanism; Case A proves the current Windows UI, not a permanent UI contract.
- Runtime/owner probe failures block recovery and leave normal commit verification running; they do not trigger another dispatch.
- Attachments remain outside this recovery lane.