### PR TITLE
Fix Windows CI test assumptions

### DIFF
--- a/docs/windows-work.md
+++ b/docs/windows-work.md
@@ -7,6 +7,8 @@ Read this file whenever you're working from Windows and add new findings so the 
 - The agent-scripts `runner` helper can fail under PowerShell/CMD because of CRLF and bash expectations. If it explodes, run commands directly (`pnpm ...`, `git add/commit`) instead.
 - browser-tools binary: not built in `agent-scripts/bin` on Windows; `pnpm tsx scripts/browser-tools.ts` also fails there (no package manifest). Use a macOS-built binary or run from macOS if you need it.
 - Prefer PowerShell + pnpm directly; watch for CRLF warnings when touching tracked files.
+- Native Windows file stats do not expose POSIX permission bits. Keep sealed-content and argv tests active there, but assert owner-only `0600` modes on POSIX runners.
+- Cross-platform tests should build path fragments with `node:path` and normalize CRLF before asserting multiline tracked text.
 - WSL browser launch host detection: a systemd-resolved stub such as `nameserver 127.0.0.53` is guest loopback, not the Windows host. Keep resolver-derived non-loopback hosts for Windows Chrome compatibility, but route resolver-derived `127/8` values to the standard local Chrome launcher.
 
 Future Windows gotchas belong here. Update this doc when you learn something new.

--- a/tests/browser/opencliTransport.test.ts
+++ b/tests/browser/opencliTransport.test.ts
@@ -193,7 +193,9 @@ describe("OpenCliBrowserTransport", () => {
     const artifactPath = result.artifacts?.[0]?.path;
     expect(artifactPath).toBeTruthy();
     expect(await fs.readFile(artifactPath!, "utf8")).toContain(privatePrompt);
-    expect((await fs.stat(artifactPath!)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(artifactPath!)).mode & 0o777).toBe(0o600);
+    }
   });
 
   it("opens the stored conversation explicitly for an Oracle follow-up", async () => {

--- a/tests/cli/dedicatedBrowser.test.ts
+++ b/tests/cli/dedicatedBrowser.test.ts
@@ -96,17 +96,16 @@ describe("dedicated browser application identity", () => {
   });
 
   test("finds the containing app bundle from a macOS executable path", () => {
-    expect(
-      findContainingAppBundle(
-        "/tmp/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
-      ),
-    ).toBe("/tmp/Google Chrome for Testing.app");
-    expect(findContainingAppBundle("/usr/bin/chromium")).toBeNull();
+    const appBundle = path.resolve("/tmp/Google Chrome for Testing.app");
+    const executable = path.join(appBundle, "Contents", "MacOS", "Google Chrome for Testing");
+    expect(findContainingAppBundle(executable)).toBe(appBundle);
+    expect(findContainingAppBundle(path.resolve("/usr/bin/chromium"))).toBeNull();
   });
 
   test("matches a running process only to the configured dedicated executable", () => {
-    const dedicatedExecutable =
-      "/tmp/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing";
+    const dedicatedExecutable = path.resolve(
+      "/tmp/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+    );
     expect(
       browserCommandUsesExecutable(
         `${dedicatedExecutable} --remote-debugging-port=9333`,
@@ -115,7 +114,9 @@ describe("dedicated browser application identity", () => {
     ).toBe(true);
     expect(
       browserCommandUsesExecutable(
-        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=9333",
+        `${path.resolve(
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        )} --remote-debugging-port=9333`,
         dedicatedExecutable,
       ),
     ).toBe(false);

--- a/tests/cli/dryRun.coverage.test.ts
+++ b/tests/cli/dryRun.coverage.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import { runDryRunSummary, runBrowserPreview } from "../../src/cli/dryRun.js";
 import type { RunOracleOptions } from "../../src/oracle/types.js";
@@ -155,7 +156,7 @@ describe("runDryRunSummary", () => {
 
     const joined = log.mock.calls.flat().join("\n");
     expect(joined).toContain("Authentication: dedicated persistent Chrome profile");
-    expect(joined).toContain(".oracle/browser-profile");
+    expect(joined).toContain(path.join(".oracle", "browser-profile"));
     expect(joined).toContain("No files attached");
   });
 

--- a/tests/opencli-adapters/submit-file-core.test.ts
+++ b/tests/opencli-adapters/submit-file-core.test.ts
@@ -82,7 +82,9 @@ describe("OpenCLI submit-file adapter core", () => {
       { event: "model-ready", operationRef, reportedModel: "Pro" },
       { event: "dispatch-intent", operationRef, attempt: 1 },
     ]);
-    expect((await fs.stat(journalPath)).mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect((await fs.stat(journalPath)).mode & 0o777).toBe(0o600);
+    }
   });
 
   it("rejects payload mutation after Oracle authorization", async () => {

--- a/tests/oracle/skillContract.test.ts
+++ b/tests/oracle/skillContract.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, test } from "vitest";
 
 describe("canonical Oracle skill contract", () => {
   test("pins the GPT-5.6 Pro direct-CDP browser lane without provider fallback", async () => {
-    const skill = await readFile(path.join(process.cwd(), "skills/oracle/SKILL.md"), "utf8");
+    const skill = (
+      await readFile(path.join(process.cwd(), "skills/oracle/SKILL.md"), "utf8")
+    ).replace(/\r\n/g, "\n");
 
     expect(skill).toContain("--engine browser --browser-transport cdp --model gpt-5-pro");
     expect(skill).toContain("--browser-thinking-time pro");


### PR DESCRIPTION
## Summary

- keep sealed-content and private-argv tests active on Windows while checking POSIX `0600` mode bits only where the OS exposes them
- make dedicated-browser and dry-run path assertions use host-native `node:path` semantics
- normalize CRLF before checking the tracked Oracle skill contract
- document the cross-platform test rules in `docs/windows-work.md`

This is an owner-side test/docs maintenance change. It does not modify production behavior and is intentionally separate from PR #2.

## Validation

- focused affected tests: 34 passed across 5 files
- full Vitest: 1767 passed / 31 skipped
- lint and typecheck: passed
- docs check: passed
- build: passed
- `git diff --cached --check`: passed